### PR TITLE
fix: remove duplicate parameters, fix invalid patterns and examples

### DIFF
--- a/plex-api-spec.yaml
+++ b/plex-api-spec.yaml
@@ -1120,7 +1120,7 @@ paths:
           in: query
           schema:
             type: string
-          example: 123
+          example: '123'
         - name: time
           description: The current time offset of playback in ms.
           in: query
@@ -1199,12 +1199,6 @@ paths:
         - name: url
           description: Alternative to key/ratingKey (legacy).
           in: query
-          schema:
-            type: string
-        - name: X-Plex-Client-Identifier
-          description: Unique per client.
-          in: header
-          required: true
           schema:
             type: string
         - name: X-Plex-Session-Identifier
@@ -6812,7 +6806,7 @@ paths:
           in: query
           schema:
             type: string
-            format: url
+            format: uri
           example: file:///storage%2Femulated%2F0%2FArcher-S01E01.mkv
         - name: virtualFilePath
           description: A virtual path to use when the url is opaque.
@@ -9529,7 +9523,8 @@ paths:
             type: array
             items:
               type: string
-          example: device[]=device://tv.plex.grabbers.hdhomerun/1053C0CA
+          example:
+            - device://tv.plex.grabbers.hdhomerun/1053C0CA
         - name: language
           description: The language.
           in: query
@@ -17673,7 +17668,9 @@ paths:
             type: array
             items:
               type: string
-          example: viewedAt:desc,accountID
+          example:
+            - viewedAt:desc
+            - accountID
         - name: excludeElements
           description: Comma-separated list of elements to exclude from the response
           in: query
@@ -20064,7 +20061,7 @@ paths:
           in: query
           schema:
             type: string
-            pattern: ^\d[x:]\d$
+            pattern: ^\d+[x:]\d+$
           example: 1080x1080
         - name: protocol
           description: "Indicates the network streaming protocol to be used for the transcode session: * 'http' - include the file in the http response such as MKV streaming * 'hls' - hls stream (RFC 8216) * 'dash' - dash stream (ISO/IEC 23009-1:2022)"
@@ -20133,12 +20130,6 @@ paths:
             minimum: 0
             maximum: 99
           example: 50
-        - name: X-Plex-Client-Identifier
-          description: Unique per client.
-          in: header
-          required: true
-          schema:
-            type: string
         - name: X-Plex-Client-Profile-Extra
           description: See [Profile Augmentations](#section/API-Info/Profile-Augmentations) .
           in: header
@@ -20151,30 +20142,6 @@ paths:
           schema:
             type: string
           example: generic
-        - name: X-Plex-Device
-          description: Device the client is running on
-          in: header
-          schema:
-            type: string
-          example: Windows
-        - name: X-Plex-Model
-          description: Model of the device the client is running on
-          in: header
-          schema:
-            type: string
-          example: standalone
-        - name: X-Plex-Platform
-          description: Client Platform
-          in: header
-          schema:
-            type: string
-          example: Chrome
-        - name: X-Plex-Platform-Version
-          description: Client Platform Version
-          in: header
-          schema:
-            type: string
-          example: 135
         - name: X-Plex-Session-Identifier
           description: Unique per client playback session.  Used if a client can playback multiple items at a time (such as a browser with multiple tabs)
           in: header
@@ -20724,7 +20691,7 @@ paths:
           in: query
           schema:
             type: string
-            pattern: ^\d[x:]\d$
+            pattern: ^\d+[x:]\d+$
           example: 1080x1080
         - name: protocol
           description: "Indicates the network streaming protocol to be used for the transcode session: * 'http' - include the file in the http response such as MKV streaming * 'hls' - hls stream (RFC 8216) * 'dash' - dash stream (ISO/IEC 23009-1:2022)"
@@ -20793,12 +20760,6 @@ paths:
             minimum: 0
             maximum: 99
           example: 50
-        - name: X-Plex-Client-Identifier
-          description: Unique per client.
-          in: header
-          required: true
-          schema:
-            type: string
         - name: X-Plex-Client-Profile-Extra
           description: See [Profile Augmentations](#section/API-Info/Profile-Augmentations) .
           in: header
@@ -20811,30 +20772,6 @@ paths:
           schema:
             type: string
           example: generic
-        - name: X-Plex-Device
-          description: Device the client is running on
-          in: header
-          schema:
-            type: string
-          example: Windows
-        - name: X-Plex-Model
-          description: Model of the device the client is running on
-          in: header
-          schema:
-            type: string
-          example: standalone
-        - name: X-Plex-Platform
-          description: Client Platform
-          in: header
-          schema:
-            type: string
-          example: Chrome
-        - name: X-Plex-Platform-Version
-          description: Client Platform Version
-          in: header
-          schema:
-            type: string
-          example: 135
         - name: X-Plex-Session-Identifier
           description: Unique per client playback session.  Used if a client can playback multiple items at a time (such as a browser with multiple tabs)
           in: header
@@ -32282,17 +32219,6 @@ paths:
           required: true
           schema:
             type: integer
-        - name: type
-          description: Filter by metadata type (1=movie, 2=show, 3=season, 4=episode, 8=artist, 9=album, 10=track)
-          in: query
-          schema:
-            type: integer
-          x-speakeasy-name-override: mediaType
-        - name: sort
-          description: Sort key and direction (e.g. addedAt:desc, titleSort)
-          in: query
-          schema:
-            type: string
         - name: includeMeta
           description: Adds the Meta object to the response
           in: query
@@ -33624,12 +33550,6 @@ paths:
           required: true
           schema:
             type: integer
-        - name: type
-          description: Item type
-          in: query
-          schema:
-            type: integer
-          x-speakeasy-name-override: mediaType
         - name: field.query
           description: The "field" stands in for any field, the value is a partial string for matching
           in: query
@@ -36719,12 +36639,6 @@ paths:
           required: true
           schema:
             type: integer
-        - name: type
-          description: Item type
-          in: query
-          schema:
-            type: integer
-          x-speakeasy-name-override: mediaType
       responses:
         '200':
           description: OK
@@ -38188,17 +38102,6 @@ paths:
           description: Section identifier
           in: path
           required: true
-          schema:
-            type: integer
-        - name: type
-          description: The metadata type to filter on
-          in: query
-          schema:
-            type: integer
-          x-speakeasy-name-override: mediaType
-        - name: sort
-          description: The metadata type to filter on
-          in: query
           schema:
             type: integer
       responses:
@@ -46022,7 +45925,10 @@ paths:
             type: array
             items:
               type: string
-          example: 46.1,44.1,45.1
+          example:
+            - '46.1'
+            - '44.1'
+            - '45.1'
       responses:
         '200':
           description: OK
@@ -50659,7 +50565,7 @@ paths:
           in: query
           schema:
             type: string
-            pattern: ^\d[x:]\d$
+            pattern: ^\d+[x:]\d+$
           example: 1080x1080
         - name: protocol
           description: "Indicates the network streaming protocol to be used for the transcode session: * 'http' - include the file in the http response such as MKV streaming * 'hls' - hls stream (RFC 8216) * 'dash' - dash stream (ISO/IEC 23009-1:2022)"
@@ -50728,12 +50634,6 @@ paths:
             minimum: 0
             maximum: 99
           example: 50
-        - name: X-Plex-Client-Identifier
-          description: Unique per client.
-          in: header
-          required: true
-          schema:
-            type: string
         - name: X-Plex-Client-Profile-Extra
           description: See [Profile Augmentations](#section/API-Info/Profile-Augmentations) .
           in: header
@@ -50746,30 +50646,6 @@ paths:
           schema:
             type: string
           example: generic
-        - name: X-Plex-Device
-          description: Device the client is running on
-          in: header
-          schema:
-            type: string
-          example: Windows
-        - name: X-Plex-Model
-          description: Model of the device the client is running on
-          in: header
-          schema:
-            type: string
-          example: standalone
-        - name: X-Plex-Platform
-          description: Client Platform
-          in: header
-          schema:
-            type: string
-          example: Chrome
-        - name: X-Plex-Platform-Version
-          description: Client Platform Version
-          in: header
-          schema:
-            type: string
-          example: 135
         - name: X-Plex-Session-Identifier
           description: Unique per client playback session.  Used if a client can playback multiple items at a time (such as a browser with multiple tabs)
           in: header
@@ -54306,7 +54182,6 @@ paths:
               uri: library://82503060-0d68-4603-b594-8b071d54819e/item/%2Flibrary%2Fmetadata%2F146
             locationID: -1
             Policy:
-              value: ''
               scope: all
               unwatched: 0
             target: ''
@@ -55700,7 +55575,7 @@ components:
       in: query
       schema:
         type: string
-        pattern: ^\d[x:]\d$
+        pattern: ^\d+[x:]\d+$
       example: 1080x1080
     protocol:
       name: protocol
@@ -55816,7 +55691,7 @@ components:
       in: query
       schema:
         type: string
-        pattern: ^\d[x:]\d$
+        pattern: ^\d+[x:]\d+$
       example: 1080x1080
     X-Plex-Client-Identifier:
       name: X-Plex-Client-Identifier

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -9,9 +9,11 @@ plugins:
   - ./plugins/arazzo-ref-rules.js
 rules:
   plex/operation-ref-resolves: error
-  # Ratchet: pre-existing violations in the generated spec (duplicate
-  # X-Plex-* params in transcode/timeline ops; two trailing-slash paths).
+  # The duplicate X-Plex-* params in the transcode/timeline ops are fixed,
+  # so this is promoted to error per the ratchet note that used to live
+  # here. If the generator reintroduces duplicates, CI now catches it.
+  operation-parameters-unique: error
+  # Ratchet: two pre-existing trailing-slash paths in the generated spec.
   # Warn now, promote to error once the generator is fixed. Do not add new
   # violations.
-  operation-parameters-unique: warn
   no-path-trailing-slash: warn


### PR DESCRIPTION
**Rebased onto the post-#117 regenerated spec.** Several of the original fixes (invalid `Burn` enums, orphan components, missing `info` fields, undeclared tags) were resolved by the regeneration; this PR carries the defect classes that persist in the new spec.

## What changed

- **Removed the 16 duplicate inline `X-Plex-*` header parameters** on the three `/{transcodeType}/:/transcode/universal/*` operations and `POST /:/timeline` — the component refs on the same operations already declare them. `redocly.yaml` had these baselined with a note to "promote to error once fixed"; this PR does both: **`operation-parameters-unique` is now `error`**, so a generator regression fails CI.
- **Fixed the resolution pattern** `^\d[x:]\d$` → `^\d+[x:]\d+$` (5 occurrences, `videoResolution`/`photoResolution`): the old pattern only matches single digits, so every real value like `1080x1080` failed validation.
- **Removed inline `type`/`sort` query params duplicated by the exploded `mediaQuery` object** on `/library/sections/{sectionId}/all`, `/autocomplete`, `/common`, `/firstCharacters` (the regeneration added the `/all` case). Same query key was documented twice per operation; the `mediaQuery` versions are better typed. This duplication also makes oasdiff's parameter matching nondeterministic, which matters for the breaking-change gate in the follow-up PR.
- **Fixed the remaining invalid parameter examples**: `playQueueItemID` (numeric example on string param), `device`/`sort`/`channelsEnabled` (scalar examples on array params), `Policy.value` (empty-string example on integer).
- **`/library/file` `url` param**: non-standard `format: url` → `format: uri`.

## Result

- `operation-parameters-unique`: 16 → 0, now enforced at error severity
- `no-invalid-parameter-examples`: 14 → 0
- Verified locally against the full validate.yml stack: prettier clean, Redocly clean, vacuum score unchanged at the 25 baseline

## Not addressed (pre-existing, separate effort)

The regenerated spec carries ~371 invalid examples (`no-invalid-media-type-examples`: 322, `no-invalid-schema-examples`: 49) and 2 trailing-slash paths — these look like example-generation defects in the pipeline that produced the spec and deserve their own fix at the source.

## Note for reviewers

These corrections are technically "breaking" relative to the published spec (parameter removals, pattern tightening) — they fix documentation to match reality rather than changing any API. Under the gate added in the stacked PR, this is what the `breaking-change` label acknowledges.
