### PR TITLE
ci: gate breaking spec changes with oasdiff; fix sdk_generation trigger

### DIFF
--- a/.github/workflows/breaking-changes.yml
+++ b/.github/workflows/breaking-changes.yml
@@ -1,0 +1,41 @@
+name: Breaking Changes
+
+# Compares the PR's spec against the base branch with oasdiff and fails on
+# changes that would break existing API clients (and the eight generated
+# SDKs). Label the PR 'breaking-change' to acknowledge an intentional
+# break: the report is still produced, but the job passes.
+
+on:
+  pull_request:
+    # No branches filter: stacked PRs (base != main) get the gate too.
+    paths:
+      - "plex-api-spec.yaml"
+      - ".github/workflows/breaking-changes.yml"
+
+permissions:
+  contents: read
+  pull-requests: write # lets oasdiff post its review link as a PR comment
+
+concurrency:
+  group: breaking-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  breaking-changes:
+    name: Breaking-change gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Fetch base branch
+        run: git fetch --depth=1 origin "$GITHUB_BASE_REF"
+
+      - name: Detect breaking changes (oasdiff)
+        uses: oasdiff/oasdiff-action/breaking@033c15c845bef10f148afb0fa781bf1b2a7fe1bf # v0.1.12
+        with:
+          base: "origin/${{ github.base_ref }}:plex-api-spec.yaml"
+          revision: "HEAD:plex-api-spec.yaml"
+          fail-on: ${{ !contains(github.event.pull_request.labels.*.name, 'breaking-change') && 'WARN' || '' }}
+          github-token: ${{ github.token }}

--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -18,7 +18,7 @@ permissions:
       - main
     paths:
       - .github/workflows/sdk_generation.yaml
-      - ./plex-api-spec.yaml
+      - plex-api-spec.yaml
 jobs:
   generate:
     uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15


### PR DESCRIPTION
**Rebuilt after #117 landed.** The original version of this PR added Redocly lint gating, a warning baseline, and prettier decisions — all now superseded by `validate.yml` (Redocly + Speakeasy + vacuum + prettier + Arazzo lint). What upstream still lacks is exactly what remains here. Stacked on #127; auto-retargets to `main` when it merges.

## What changed

### New workflow: `breaking-changes.yml`

oasdiff compares the PR's spec against the base branch and **fails on changes that would break existing API clients** — and therefore the eight generated SDKs. `validate.yml` covers static correctness but says nothing about client compatibility; this closes that gap.

- `fail-on: WARN` (strict: definite and potentially-breaking changes both fail)
- Intentional breaks are acknowledged by labeling the PR `breaking-change`: the report is still produced and posted, but the job passes
- Follows repo conventions: SHA-pinned actions, `persist-credentials: false`, concurrency group, paths filter
- Requires the `mediaQuery` de-duplication in #127: with duplicate query keys present, oasdiff's parameter matching is nondeterministic and reports phantom breaking changes on identical specs (verified: 3× self-diff clean after the fix)

### Fix: `sdk_generation.yaml` paths filter

`./plex-api-spec.yaml` never matched anything (GitHub Actions path globs are repo-root-relative without `./`), so spec pushes did not actually trigger SDK generation — masked by the hourly cron.
