### PR TITLE
feat: document audio transcode parameters

### DIFF
--- a/plex-api-spec.yaml
+++ b/plex-api-spec.yaml
@@ -50546,6 +50546,12 @@ paths:
           schema:
             type: integer
             minimum: 0
+        - name: X-Plex-Client-Profile-Extra
+          description: Profile augmentations supplied as a query parameter by some music transcode clients.
+          in: query
+          schema:
+            type: string
+          x-speakeasy-name-override: clientProfileExtraQuery
         - name: offset
           description: Offset from the start of the media (in seconds).
           in: query

--- a/plex-api-spec.yaml
+++ b/plex-api-spec.yaml
@@ -50435,6 +50435,11 @@ paths:
         - $ref: "#/components/parameters/transcodeType"
         - $ref: "#/components/parameters/transcodeSessionId"
         - $ref: "#/components/parameters/advancedSubtitles"
+        - name: session
+          description: Playback session UUID used by music transcode clients.
+          in: query
+          schema:
+            type: string
         - name: platform
           description: Client platform (some clients send this in addition to headers).
           in: query
@@ -50535,6 +50540,12 @@ paths:
             type: integer
             minimum: 0
           example: 5000
+        - name: maxAudioBitrate
+          description: Maximum audio bitrate for music transcodes, in kbps.
+          in: query
+          schema:
+            type: integer
+            minimum: 0
         - name: offset
           description: Offset from the start of the media (in seconds).
           in: query


### PR DESCRIPTION
Agent: Documents the audio-specific query parameters used with the existing universal transcode endpoint:

- `session`, the playback session UUID used by music clients
- `maxAudioBitrate`, the requested audio bitrate ceiling

The generic `/{transcodeType}/:/transcode/universal/start.{extension}` route already covers `/music/:/transcode/universal/start.m3u8`, so this avoids introducing a duplicate OpenAPI path while making the reported request representable.

Closes #41

## Validation

- `npm run validate`
- `speakeasy lint openapi -s plex-api-spec.yaml` — 0 errors; existing warning baseline
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This change extends the universal-transcode request contract for music clients by documenting the playback `session`, `maxAudioBitrate`, and query-form `X-Plex-Client-Profile-Extra` parameters. Focused contract checks confirmed that the query and header profile-augmentation parameters remain distinct in both OpenAPI identity and generated SDK naming. The complete specification also passes Redocly validation and formatting checks.
</details>

<h3>Confidence Score: 5/5</h3>

The documented request contract is structurally valid and preserves distinct handling for the query and header forms of the client-profile parameter.

Focused parsing and serialization checks passed for the changed parameters, and full-spec validation and formatting checks completed successfully. No defects were found.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the universal-transcode contract validation script against plex-api-spec.yaml and verified the distinct SDK name and the session and maxAudioBitrate schemas.
- Linted the plex-api-spec.yaml with Redocly; the lint run exited successfully and the API description was reported as valid.
- The focused universal-transcode contract assertion was checked on the current revision: it failed on the parent revision because the new query parameter was absent, and then passed on this revision with separate query/header parameter identities and wire serialization.

<a href="https://app.greptile.com/trex/runs/18728204/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: support query profile augmentations"](https://github.com/lukasparke/plex-api-spec/commit/c2b6c280c8d1130a7c8ea23869eebdec000f174e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53025408)</sub>

<!-- /greptile_comment -->