### PR TITLE
feat: document accepting Plex invitations

### DIFF
--- a/plex-api-spec.yaml
+++ b/plex-api-spec.yaml
@@ -20906,6 +20906,68 @@ paths:
             text/html:
               schema:
                 type: string
+  /api/invites/requests/{inviteId}:
+    put:
+      operationId: acceptInvite
+      summary: Accept an Invite
+      tags:
+        - Users
+      description: Accept a pending Plex friend, home, or server invitation.
+      servers:
+        - url: https://plex.tv
+      parameters:
+        - $ref: "#/components/parameters/accepts"
+        - $ref: "#/components/parameters/X-Plex-Client-Identifier"
+        - $ref: "#/components/parameters/X-Plex-Product"
+        - $ref: "#/components/parameters/X-Plex-Version"
+        - $ref: "#/components/parameters/X-Plex-Platform"
+        - $ref: "#/components/parameters/X-Plex-Platform-Version"
+        - $ref: "#/components/parameters/X-Plex-Device"
+        - $ref: "#/components/parameters/X-Plex-Model"
+        - $ref: "#/components/parameters/X-Plex-Device-Vendor"
+        - $ref: "#/components/parameters/X-Plex-Device-Name"
+        - $ref: "#/components/parameters/X-Plex-Marketplace"
+        - name: inviteId
+          description: The pending invitation ID.
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: friend
+          description: Whether the invitation includes a friend relationship.
+          in: query
+          required: true
+          schema:
+            $ref: "#/components/schemas/BoolInt"
+        - name: home
+          description: Whether the invitation includes Plex Home membership.
+          in: query
+          required: true
+          schema:
+            $ref: "#/components/schemas/BoolInt"
+        - name: server
+          description: Whether the invitation includes access to a shared server.
+          in: query
+          required: true
+          schema:
+            $ref: "#/components/schemas/BoolInt"
+      responses:
+        '200':
+          description: Invitation accepted.
+          content:
+            application/xml:
+              schema:
+                type: object
+                additionalProperties: true
+        '400':
+          $ref: "#/components/responses/400"
+          description: Bad Request - Invalid invitation or parameters
+        '401':
+          $ref: "#/components/responses/401"
+          description: Unauthorized - Authentication token is missing or invalid
+        '404':
+          $ref: "#/components/responses/404"
+          description: Invitation not found
   /butler/{butlerTask}:
     delete:
       operationId: stopTask


### PR DESCRIPTION
Agent: Documents the Plex.tv operation used to accept pending friend, home, and server invitations.

The operation follows the maintained Python-PlexAPI implementation:

- `PUT https://plex.tv/api/invites/requests/{inviteId}`
- required `friend`, `home`, and `server` boolean-integer flags
- legacy XML success response

Closes #87

## Validation

- `npm run validate`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

## Summary
This change documents the Plex.tv endpoint for accepting pending friend, home, and server invitations.

The documented PUT request was checked for its route, Plex.tv server override, required invitation ID and integer scope flags, inherited token authentication, and XML success response. The unauthenticated live route returned the documented authentication failure behavior. No defects were found.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the added API documentation forms a valid, authenticated OpenAPI contract.

A focused YAML validator confirmed the added operation's path, method, server, required parameters, integer-backed flags, inherited security, and XML response declaration. Full-spec OpenAPI lint completed successfully, and a live unauthenticated request confirmed that the documented route enforces authentication.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the authored Node.js YAML validator against the parent revision and the updated specification, and confirmed the updated spec passes assertions for PUT /api/invites/requests/{inviteId}, the Plex.tv server override, required integer invitation flags, inherited X-Plex-Token authentication, and the XML success response.
- Sent a PUT to the Plex.tv invites endpoint without credentials and observed a 401 Unauthorized with the XML message 'Please sign in.', proving authentication is enforced for the invitation operation.
- Ran Redocly lint on the invitation operation OpenAPI spec and it exited successfully.
- Disproved structurally that the PUT path, Plex.tv server override, required integer flags, or inherited token security were missing or malformed, since the unauthenticated request returned 401 and no authenticated success path was observed.

<a href="https://app.greptile.com/trex/runs/18727365/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: document accepting invitations"](https://github.com/lukasparke/plex-api-spec/commit/e7e566b464745d63a4a5d557542b8631cf34b4e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53025406)</sub>

<!-- /greptile_comment -->