### PR TITLE
feat: document optimized version jobs

### DIFF
--- a/plex-api-spec.yaml
+++ b/plex-api-spec.yaml
@@ -48735,10 +48735,17 @@ paths:
                 type: string
     put:
       operationId: addPlaylistItems
-      summary: Adding to  a Playlist
+      summary: Add Items or an Optimization Job to a Playlist
       tags:
         - Library Playlists
-      description: Adds a generator to a playlist, same parameters as the POST above. With a dumb playlist, this adds the specified items to the playlist. With a smart playlist, passing a new `uri` parameter replaces the rules for the playlist. Returns the playlist.
+      description: |-
+        Adds items or a generator to a playlist. With a dumb playlist, this adds the specified items.
+        With a smart playlist, passing a new `uri` replaces the rules.
+
+        To create an optimized media version, first retrieve the background-processing playlist
+        with `GET /playlists?type=42`, then add an item to that playlist with `Item[type]=42`,
+        an `Item[Location][uri]` that identifies the media, and either `Item[targetTagID]` for a
+        built-in optimization profile or custom `Item[MediaSettings][...]` values.
       parameters:
         - $ref: "#/components/parameters/accepts"
         - $ref: "#/components/parameters/X-Plex-Client-Identifier"
@@ -48767,6 +48774,89 @@ paths:
           in: query
           schema:
             type: integer
+        - name: Item[type]
+          description: Item type. Use 42 to create an optimized-version job.
+          in: query
+          schema:
+            type: integer
+            enum:
+              - 42
+          x-speakeasy-name-override: itemType
+        - name: Item[title]
+          description: Display title for the optimization job.
+          in: query
+          schema:
+            type: string
+          x-speakeasy-name-override: itemTitle
+        - name: Item[target]
+          description: Custom optimization target name.
+          in: query
+          schema:
+            type: string
+          x-speakeasy-name-override: itemTarget
+        - name: Item[targetTagID]
+          description: ID of a built-in media-processing target such as Optimized for Mobile.
+          in: query
+          schema:
+            type: integer
+          x-speakeasy-name-override: itemTargetTagId
+        - name: Item[locationID]
+          description: Destination library location ID. Use -1 to store the optimized version with the original media.
+          in: query
+          schema:
+            type: integer
+            minimum: -1
+          x-speakeasy-name-override: itemLocationId
+        - name: Item[Location][uri]
+          description: Plex library URI identifying the media to optimize.
+          in: query
+          schema:
+            type: string
+          x-speakeasy-name-override: itemLocationUri
+        - name: Item[Policy][scope]
+          description: Optimization policy scope, such as all or count.
+          in: query
+          schema:
+            type: string
+          x-speakeasy-name-override: itemPolicyScope
+        - name: Item[Policy][value]
+          description: Maximum item count when the policy scope is count.
+          in: query
+          schema:
+            type: integer
+            minimum: 0
+          x-speakeasy-name-override: itemPolicyValue
+        - name: Item[Policy][unwatched]
+          description: Whether to optimize only unwatched items.
+          in: query
+          schema:
+            $ref: "#/components/schemas/BoolInt"
+          x-speakeasy-name-override: itemPolicyUnwatched
+        - name: Item[Device][profile]
+          description: Client device profile used for a custom optimization target.
+          in: query
+          schema:
+            type: string
+          x-speakeasy-name-override: itemDeviceProfile
+        - name: Item[MediaSettings][videoQuality]
+          description: Video quality index for a custom optimization target.
+          in: query
+          schema:
+            type: integer
+          x-speakeasy-name-override: itemVideoQuality
+        - name: Item[MediaSettings][videoResolution]
+          description: Maximum video resolution for a custom optimization target.
+          in: query
+          schema:
+            type: string
+          x-speakeasy-name-override: itemVideoResolution
+        - name: Item[MediaSettings][maxVideoBitrate]
+          description: Maximum video bitrate in kbps for a custom optimization target.
+          in: query
+          schema:
+            type: integer
+            minimum: 0
+          x-speakeasy-name-override: itemMaxVideoBitrate
       responses:
         '200':
           $ref: "#/components/responses/slash-post-responses-200"

--- a/plex-api-spec.yaml
+++ b/plex-api-spec.yaml
@@ -48744,8 +48744,13 @@ paths:
 
         To create an optimized media version, first retrieve the background-processing playlist
         with `GET /playlists?type=42`, then add an item to that playlist with `Item[type]=42`,
-        an `Item[Location][uri]` that identifies the media, and either `Item[targetTagID]` for a
-        built-in optimization profile or custom `Item[MediaSettings][...]` values.
+        an `Item[Location][uri]` that identifies the media, and one of these target configurations:
+
+        - A built-in profile specified by `Item[targetTagID]`.
+        - A custom target specified by `Item[target]`, `Item[Device][profile]`, and
+          `Item[MediaSettings][videoQuality]` together. The remaining media settings describe
+          the custom target. Original quality uses empty strings for video quality, resolution,
+          and maximum bitrate.
       parameters:
         - $ref: "#/components/parameters/accepts"
         - $ref: "#/components/parameters/X-Plex-Client-Identifier"
@@ -48789,13 +48794,13 @@ paths:
             type: string
           x-speakeasy-name-override: itemTitle
         - name: Item[target]
-          description: Custom optimization target name.
+          description: Custom optimization target name. Required with Item[Device][profile] and Item[MediaSettings][videoQuality] when Item[targetTagID] is not used.
           in: query
           schema:
             type: string
           x-speakeasy-name-override: itemTarget
         - name: Item[targetTagID]
-          description: ID of a built-in media-processing target such as Optimized for Mobile.
+          description: ID of a built-in media-processing target such as Optimized for Mobile. Use this instead of the custom-target parameters.
           in: query
           schema:
             type: integer
@@ -48814,7 +48819,7 @@ paths:
             type: string
           x-speakeasy-name-override: itemLocationUri
         - name: Item[Policy][scope]
-          description: Optimization policy scope, such as all or count.
+          description: Optimization policy scope. The only valid values are all and count.
           in: query
           schema:
             type: string
@@ -48836,16 +48841,20 @@ paths:
             $ref: "#/components/schemas/BoolInt"
           x-speakeasy-name-override: itemPolicyUnwatched
         - name: Item[Device][profile]
-          description: Client device profile used for a custom optimization target.
+          description: Client device profile used for a custom optimization target. Required with Item[target] and Item[MediaSettings][videoQuality].
           in: query
           schema:
             type: string
           x-speakeasy-name-override: itemDeviceProfile
         - name: Item[MediaSettings][videoQuality]
-          description: Video quality index for a custom optimization target.
+          description: Video quality index for a custom optimization target, or an empty string for original quality. Required with Item[target] and Item[Device][profile].
           in: query
           schema:
-            type: integer
+            oneOf:
+              - type: integer
+              - type: string
+                enum:
+                  - ''
           x-speakeasy-name-override: itemVideoQuality
         - name: Item[MediaSettings][videoResolution]
           description: Maximum video resolution for a custom optimization target.
@@ -48854,11 +48863,15 @@ paths:
             type: string
           x-speakeasy-name-override: itemVideoResolution
         - name: Item[MediaSettings][maxVideoBitrate]
-          description: Maximum video bitrate in kbps for a custom optimization target.
+          description: Maximum video bitrate in kbps for a custom optimization target, or an empty string for original quality.
           in: query
           schema:
-            type: integer
-            minimum: 0
+            oneOf:
+              - type: integer
+                minimum: 0
+              - type: string
+                enum:
+                  - ''
           x-speakeasy-name-override: itemMaxVideoBitrate
       responses:
         '200':

--- a/plex-api-spec.yaml
+++ b/plex-api-spec.yaml
@@ -48818,6 +48818,9 @@ paths:
           in: query
           schema:
             type: string
+            enum:
+              - all
+              - count
           x-speakeasy-name-override: itemPolicyScope
         - name: Item[Policy][value]
           description: Maximum item count when the policy scope is count.


### PR DESCRIPTION
Agent: Documents how PMS creates optimized media versions through the existing playlist-items operation.

The maintained Python-PlexAPI implementation shows that clients:

1. retrieve the background-processing playlist with `GET /playlists?type=42`
2. `PUT /playlists/{playlistId}/items` with `Item[type]=42`
3. provide the source library URI, target profile, policy, destination, and optional custom video settings

This PR adds those `Item[...]` parameters to the existing operation and explains the workflow without introducing a duplicate endpoint.

Closes #20

## Validation

- `npm run validate`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded playlist item operations to support creating optimized-media jobs.
  * Added options for optimization type, title, destination, source, policy, device profile, video quality, resolution, and bitrate.
  * Added support for replacing smart-playlist rules during optimization workflows.

* **Documentation**
  * Clarified the workflow for adding playlist items and creating optimized media.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Documents optimized-media job creation through the playlist-items endpoint and adds typed query parameters for targets, locations, policies, device profiles, and media settings.
</details>

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The updated OpenAPI contract accepts the documented original-quality empty-string values, has no duplicate query parameters, and passes repository formatting and API-description validation.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the affected query-parameter contract before and after the change using the optimization contract check script and verified the updated contract permits integer values or an empty string for original-quality media settings and has no duplicate keys.
- Ran npm run validate; Prettier and Redocly completed successfully, and Redocly reported that the API descriptions are valid.
- Compared the operation with the analogous optimization generator contract and found no conflicting media-settings definition.
- Captured the exact before/after contract delta: integer-only before and oneOf(integer, string enum \[''\]) after.
- No repository files were modified; the only authored file is the uploaded validation script under trex-artifacts.

<a href="https://app.greptile.com/trex/runs/18730111/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: complete optimization target contra..."](https://github.com/lukasparke/plex-api-spec/commit/47876c533402d7a62c5428fa14eca55d9f7e4acb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53025404)</sub>

<!-- /greptile_comment -->